### PR TITLE
Feature: Implement instance proc validators

### DIFF
--- a/lib/goo/validators/enforce.rb
+++ b/lib/goo/validators/enforce.rb
@@ -75,7 +75,7 @@ module Goo
         end
 
         def instance_proc?(inst, opt)
-          inst.respond_to? opt
+          opt && (opt.is_a?(Symbol) || opt.is_a?(String)) && inst.respond_to?(opt)
         end
 
         def check_object_type(inst, attr, value, opt)
@@ -95,7 +95,10 @@ module Goo
 
         def call_proc(proc,inst, attr)
           # This should return an array like [:name_of_error1, "Error message 1", :name_of_error2, "Error message 2"]
-          errors = proc.call(inst, attr) || []
+          errors = proc.call(inst, attr)
+
+          return unless !errors.nil? && errors.is_a?(Array)
+
           errors.each_slice(2) do |e|
             next if e.nil? || e.compact.empty?
             add_error(e[0].to_sym, e[1])

--- a/lib/goo/validators/enforce.rb
+++ b/lib/goo/validators/enforce.rb
@@ -53,8 +53,11 @@ module Goo
               type = opt.to_s.index("max_") ? :max : :min
               check Goo::Validators::ValueRange, inst, attr, value, type, opt.to_s
             else
-              model_range = object_type(opt)
-              check_object_type inst, attr, value, model_range
+              if object_type?(opt)
+                check_object_type inst, attr, value, opt
+              elsif instance_proc?(inst, opt)
+                call_proc(inst.method(opt), inst, attr)
+              end
             end
           end
 
@@ -67,8 +70,16 @@ module Goo
           opt.respond_to?(:shape_attribute) ? opt : Goo.model_by_name(opt)
         end
 
-        def check_object_type(inst, attr, value, model_range)
+        def object_type?(opt)
+          opt.respond_to?(:shape_attribute) ? opt : Goo.model_by_name(opt)
+        end
 
+        def instance_proc?(inst, opt)
+          inst.respond_to? opt
+        end
+
+        def check_object_type(inst, attr, value, opt)
+          model_range = object_type(opt)
           if model_range && !value.nil?
             check Goo::Validators::ObjectType, inst, attr, value, model_range.model_name, model_range
           end
@@ -82,9 +93,9 @@ module Goo
            model.model_settings[:attributes][attr][:enforce]
         end
 
-        def call_proc(opt,inst, attr)
+        def call_proc(proc,inst, attr)
           # This should return an array like [:name_of_error1, "Error message 1", :name_of_error2, "Error message 2"]
-          errors = opt.call(inst, attr)
+          errors = proc.call(inst, attr) || []
           errors.each_slice(2) do |e|
             next if e.nil? || e.compact.empty?
             add_error(e[0].to_sym, e[1])


### PR DESCRIPTION
### Context

see https://github.com/agroportal/project-management/issues/393

### What

Now we can call, model-specific validators.

For example, if a  model defines an instance method called `equal_to_10` that tests if a value is equal to `10`. 

Then we can reference it as a validator for an attribute, like so `attribute :age, enforce: [:equal_to_10]`, this will enforce the attribute `age` to be `10` (as implemented in the method `equal_to_10`)

### Changes

- Add proc validator tests (https://github.com/ontoportal-lirmm/goo/pull/28/commits/f061e51612f07555680907a7809faa03f3566c1e)
- implement instance proc validators (https://github.com/ontoportal-lirmm/goo/pull/28/commits/b7cccab30510c3b4e428be66996dbbf84b52c892)