### PR TITLE
Feature: Add models on update callbacks

### DIFF
--- a/lib/goo/base/resource.rb
+++ b/lib/goo/base/resource.rb
@@ -236,6 +236,17 @@ module Goo
           raise Goo::Base::NotValidException, "Object is not valid. Check errors." unless valid?
         end
 
+        #set default values before saving
+        unless self.persistent?
+          self.class.attributes_with_defaults.each do |attr|
+            value = self.send("#{attr}")
+            if value.nil?
+              value = self.class.default(attr).call(self)
+              self.send("#{attr}=", value)
+            end
+          end
+        end
+
         graph_insert, graph_delete = Goo::SPARQL::Triples.model_update_triples(self)
         graph = self.graph()
         if graph_delete and graph_delete.size > 0

--- a/lib/goo/base/settings/settings.rb
+++ b/lib/goo/base/settings/settings.rb
@@ -96,6 +96,16 @@ module Goo
                   select{ |attr,opts| opts[:default] }).keys()
         end
 
+        def attributes_with_update_callbacks
+           (@model_settings[:attributes].
+            select{ |attr,opts| opts[:onUpdate] }).keys
+        end
+
+
+        def update_callbacks(attr)
+          @model_settings[:attributes][attr][:onUpdate]
+        end
+
         def default(attr)
           return @model_settings[:attributes][attr][:default]
         end

--- a/lib/goo/sparql/triples.rb
+++ b/lib/goo/sparql/triples.rb
@@ -67,16 +67,6 @@ module Goo
         unless model.persistent?
           graph_insert << [subject, RDF.type, model.class.uri_type(model.collection)]
         end
-        #set default values before saving
-        if not model.persistent?
-          model.class.attributes_with_defaults.each do |attr|
-            value = model.send("#{attr}")
-            if value.nil?
-              value = model.class.default(attr).call(model)
-              model.send("#{attr}=",value)
-            end
-          end
-        end
 
         model.modified_attributes.each do |attr|
           next if model.class.collection?(attr)

--- a/lib/goo/validators/enforce.rb
+++ b/lib/goo/validators/enforce.rb
@@ -64,6 +64,17 @@ module Goo
           errors_by_opt.length > 0 ? errors_by_opt : nil
         end
 
+        def enforce_callback(inst, attr)
+          callbacks = Array(inst.class.update_callbacks(attr))
+          callbacks.each do |proc|
+            if instance_proc?(inst, proc)
+              call_proc(inst.method(proc), inst, attr)
+            elsif proc.is_a?(Proc)
+              call_proc(proc, inst, attr)
+            end
+          end
+        end
+
         private
 
         def object_type(opt)
@@ -114,6 +125,10 @@ module Goo
 
       def self.enforce(inst,attr,value)
         EnforceInstance.new.enforce(inst,attr,value)
+      end
+
+      def self.enforce_callbacks(inst, attr)
+        EnforceInstance.new.enforce_callback(inst, attr)
       end
     end
   end

--- a/test/test_update_callbacks.rb
+++ b/test/test_update_callbacks.rb
@@ -1,0 +1,53 @@
+require_relative 'test_case'
+
+
+require_relative 'models'
+
+class TestUpdateCallBack < Goo::Base::Resource
+  model :update_callback_model, name_with: :code
+  attribute :code, enforce: [:string, :existence]
+  attribute :name, enforce: [:string, :existence]
+  attribute :first_name, onUpdate: :update_name
+  attribute :last_name, onUpdate: :update_name
+
+
+  def update_name(inst, attr)
+    self.name = self.first_name + self.last_name
+  end
+end
+
+class TestUpdateCallBacks < MiniTest::Unit::TestCase
+
+  def self.before_suite
+    GooTestData.delete_all [TestUpdateCallBack]
+  end
+
+  def self.after_suite
+    GooTestData.delete_all [TestUpdateCallBack]
+  end
+
+
+  def test_update_callback
+    p = TestUpdateCallBack.new
+    p.code = "1"
+    p.name = "name"
+    p.first_name = "first_name"
+    p.last_name = "last_name"
+
+    assert p.valid?
+    p.save
+
+    p.bring_remaining
+
+    assert_equal p.first_name + p.last_name, p.name
+
+    p.last_name = "last_name2"
+    p.save
+
+    p.bring_remaining
+    assert_equal  "last_name2",  p.last_name
+    assert_equal p.first_name + p.last_name, p.name
+  end
+
+end
+


### PR DESCRIPTION
### Requirement
This PR adds the possibility to add an onUpdate callback to a model attribute 

For example 

```ruby 
  attribute :name, enforce: [:string, :existence]
  attribute :first_name, onUpdate: :update_name
  attribute :last_name, onUpdate: :update_name


  def update_name(inst, attr)
    self.name = self.first_name + self.last_name
  end
``` 
Will ensure that each time we update firt_name or last_name we call the method `update_name`  and make that name will always be firt_name + last_name

### Changes

-  add onUpdate callback tests (https://github.com/ontoportal-lirmm/goo/pull/31/commits/c83687e9a65c25313df6d74be96e83ace9d939c7)

- implement enforce_callback to run an attribute callback (https://github.com/ontoportal-lirmm/goo/pull/31/commits/e4979ffbb8e1d203d0db9368be1871ba172a5b69)

- move the attribute default callback to the save method (https://github.com/ontoportal-lirmm/goo/pull/31/commits/c7f7092a228b563d4637533131446015d0f36957)

- implement onUpdate DSL in the ressource settings (https://github.com/ontoportal-lirmm/goo/pull/31/commits/f81b15fd04c10e563d40bf0ab724fa9d810a18ce)

- call to the attributes onUpdate callback in the save method (https://github.com/ontoportal-lirmm/goo/pull/31/commits/714f085983a2695f4ea8caf7dea00b8883139cb3)

