### PR TITLE
Feature: Support multilingual - Add read multiple language

### DIFF
--- a/lib/goo/sparql/mixins/solution_lang_filter.rb
+++ b/lib/goo/sparql/mixins/solution_lang_filter.rb
@@ -6,7 +6,7 @@ module Goo
         attr_reader :requested_lang, :unmapped, :objects_by_lang
 
         def initialize(requested_lang: nil, unmapped: false, list_attributes: [])
-          @attributes_to_translate = [:synonym, :prefLabel, :definition, :cui, :semanticType, :obsolete, :inScheme, :memberOf, :created, :modified, :links]
+          @attributes_to_translate = [:synonym, :prefLabel, :definition]
           @list_attributes = list_attributes
           @objects_by_lang = {}
           @unmapped = unmapped
@@ -19,7 +19,7 @@ module Goo
           objects_by_lang.each do |id, predicates|
             model = models_by_id[id]
             predicates.each do |predicate, values|
-              if !@attributes_to_translate.any? { |attr| predicate.eql?(attr) }
+              if @attributes_to_translate.any? { |attr| predicate.eql?(attr) }
                 save_model_values(model, values, predicate, unmapped) 
               end
             end

--- a/lib/goo/sparql/mixins/solution_lang_filter.rb
+++ b/lib/goo/sparql/mixins/solution_lang_filter.rb
@@ -9,13 +9,12 @@ module Goo
           @list_attributes = list_attributes
           @objects_by_lang = {}
           @unmapped = unmapped
-          @requested_lang = requested_lang
           @fill_other_languages = init_requested_lang
-          @requested_lang = @requested_lang.to_s.upcase.to_sym
+          @requested_lang = requested_lang
         end
 
         def enrich_models(models_by_id)
-
+          
           return unless fill_other_languages?
 
           other_platform_languages = Goo.main_languages[1..] || []
@@ -43,14 +42,26 @@ module Goo
         
 
         def set_model_value(model, predicate, objects, object)
-          language = object_language(object) # if lang is nil, it means that the object is not a literal
-          if language.nil?
+                    
+          if requested_lang.eql?(:ALL)
             return model.send("#{predicate}=", objects, on_load: true)
-          elsif language_match?(language)
+          end
+          
+          unless is_literal(object)
+            return model.send("#{predicate}=", objects, on_load: true)
+          end
+          
+          # here the object is a literal (but it could be with no language) 
+
+          language = object_language(object)
+
+          if language_match?(language)
             return if language.eql?(:no_lang) && !model.instance_variable_get("@#{predicate}").nil? && !objects.is_a?(Array)
 
             return model.send("#{predicate}=", objects, on_load: true)
           end
+
+          # here the object is a literal with a different language , so we store it for to enrich the model later with the other platform languages
 
           store_objects_by_lang(model.id, predicate, object, language)
         end
@@ -72,7 +83,8 @@ module Goo
         end
 
         def language_match?(language)
-          !language.nil? && (language.eql?(requested_lang) || language.eql?(:no_lang) || requested_lang.nil?)
+          # no_lang means that the object is not a literal
+          language.eql?(requested_lang) || language.eql?(:no_lang)
         end
 
         def store_objects_by_lang(id, predicate, object, language)
@@ -139,6 +151,10 @@ module Goo
 
         def fill_other_languages?
           @fill_other_languages
+        end
+
+        def is_literal(object)
+          return object_language(object).nil? ? false : true
         end
 
       end

--- a/lib/goo/sparql/mixins/solution_lang_filter.rb
+++ b/lib/goo/sparql/mixins/solution_lang_filter.rb
@@ -6,6 +6,7 @@ module Goo
         attr_reader :requested_lang, :unmapped, :objects_by_lang
 
         def initialize(requested_lang: nil, unmapped: false, list_attributes: [])
+          @attributes_to_translate = [:synonym, :prefLabel]
           @list_attributes = list_attributes
           @objects_by_lang = {}
           @unmapped = unmapped
@@ -19,7 +20,7 @@ module Goo
           objects_by_lang.each do |id, predicates|
             model = models_by_id[id]
             predicates.each do |predicate, values|
-              if predicate.eql?(:synonym) || predicate.eql?(:prefLabel)
+              if @attributes_to_translate.any? { |attr| predicate.eql?(attr) }
                 save_model_values(model, values, predicate, unmapped)
               end
             end

--- a/lib/goo/sparql/mixins/solution_lang_filter.rb
+++ b/lib/goo/sparql/mixins/solution_lang_filter.rb
@@ -32,7 +32,7 @@ module Goo
                     
           language = object_language(object)
 
-          if requested_lang.eql?(:ALL) || !is_literal(object) || language_match?(language)
+          if requested_lang.eql?(:ALL) || !literal?(object) || language_match?(language)
             model.send("#{predicate}=", objects, on_load: true)
           end 
 
@@ -144,7 +144,7 @@ module Goo
           @fill_other_languages
         end
 
-        def is_literal(object)
+        def literal?(object)
           return object_language(object).nil? ? false : true
         end
 

--- a/lib/goo/sparql/mixins/solution_lang_filter.rb
+++ b/lib/goo/sparql/mixins/solution_lang_filter.rb
@@ -44,7 +44,7 @@ module Goo
 
         def model_set_unmapped(model, predicate, value)
           language = object_language(value)
-          if language.nil? || language_match?(language)
+          if requested_lang.eql?(:ALL) || language.nil? || language_match?(language)
             return add_unmapped_to_model(model, predicate, value)
           end
           

--- a/lib/goo/sparql/mixins/solution_lang_filter.rb
+++ b/lib/goo/sparql/mixins/solution_lang_filter.rb
@@ -10,7 +10,6 @@ module Goo
           @list_attributes = list_attributes
           @objects_by_lang = {}
           @unmapped = unmapped
-          @fill_other_languages = init_requested_lang
           @requested_lang = requested_lang
         end
 
@@ -85,14 +84,6 @@ module Goo
           objects_by_lang[id][predicate][language] << object
         end
 
-        def init_requested_lang
-          if @requested_lang.nil?
-            @requested_lang = Goo.main_languages[0] || :EN
-            return true
-          end
-
-          false
-        end
 
         def get_model_attribute_value(model, predicate)
           if unmapped
@@ -139,10 +130,6 @@ module Goo
           @list_attributes.include?(predicate)
         end
 
-
-        def fill_other_languages?
-          @fill_other_languages
-        end
 
         def literal?(object)
           return object_language(object).nil? ? false : true

--- a/lib/goo/sparql/mixins/solution_lang_filter.rb
+++ b/lib/goo/sparql/mixins/solution_lang_filter.rb
@@ -84,7 +84,16 @@ module Goo
 
         def language_match?(language)
           # no_lang means that the object is not a literal
-          language.eql?(requested_lang) || language.eql?(:no_lang)
+          if language.eql?(:no_lang)
+            return true 
+          end
+
+          if requested_lang.is_a?(Array)
+            return requested_lang.include?(language)
+          end
+
+          return language.eql?(requested_lang)
+
         end
 
         def store_objects_by_lang(id, predicate, object, language)

--- a/lib/goo/sparql/mixins/solution_lang_filter.rb
+++ b/lib/goo/sparql/mixins/solution_lang_filter.rb
@@ -6,7 +6,7 @@ module Goo
         attr_reader :requested_lang, :unmapped, :objects_by_lang
 
         def initialize(requested_lang: nil, unmapped: false, list_attributes: [])
-          @attributes_to_translate = [:synonym, :prefLabel]
+          @attributes_to_translate = [:synonym, :prefLabel, :definition, :cui, :semanticType, :obsolete, :inScheme, :memberOf, :created, :modified, :links]
           @list_attributes = list_attributes
           @objects_by_lang = {}
           @unmapped = unmapped
@@ -19,8 +19,8 @@ module Goo
           objects_by_lang.each do |id, predicates|
             model = models_by_id[id]
             predicates.each do |predicate, values|
-              if @attributes_to_translate.any? { |attr| predicate.eql?(attr) }
-                save_model_values(model, values, predicate, unmapped)
+              if !@attributes_to_translate.any? { |attr| predicate.eql?(attr) }
+                save_model_values(model, values, predicate, unmapped) 
               end
             end
           end  
@@ -77,11 +77,13 @@ module Goo
 
           return if requested_lang.is_a?(Array) && !requested_lang.include?(language)
 
+          language_key = language.downcase  
+            
           objects_by_lang[id] ||= {}
           objects_by_lang[id][predicate] ||= {}
-          objects_by_lang[id][predicate][language] ||= []
+          objects_by_lang[id][predicate][language_key] ||= []
 
-          objects_by_lang[id][predicate][language] << object
+          objects_by_lang[id][predicate][language_key] << object
         end
 
 

--- a/lib/goo/sparql/solutions_mapper.rb
+++ b/lib/goo/sparql/solutions_mapper.rb
@@ -103,11 +103,14 @@ module Goo
       private
 
       def get_language(languages)
-        languages = 'ALL' if languages.nil? || languages.empty? 
+        languages = portal_language if languages.nil? || languages.empty?
         lang = languages.split(',').map {|l| l.upcase.to_sym}
-        return lang.length == 1 ? lang.first : lang
+        lang.length == 1 ? lang.first : lang
       end
 
+      def portal_language
+        Goo.main_languages.first
+      end
 
       def init_unloaded_attributes(found, list_attributes)
         return if @incl.nil?

--- a/lib/goo/sparql/solutions_mapper.rb
+++ b/lib/goo/sparql/solutions_mapper.rb
@@ -22,7 +22,7 @@ module Goo
         @incl = options[:include]
         @count = options[:count]
         @collection = options[:collection]
-        @requested_lang =  options[:requested_lang]
+        @requested_lang =  options[:requested_lang] || :ALL
       end
       
       def map_each_solutions(select)
@@ -30,9 +30,9 @@ module Goo
         objects_new = {}
         list_attributes = Set.new(@klass.attributes(:list))
         all_attributes = Set.new(@klass.attributes(:all))
+
         @lang_filter = Goo::SPARQL::Solution::LanguageFilter.new(requested_lang: @requested_lang, unmapped: @unmapped,
            list_attributes: list_attributes)
-
         
         select.each_solution do |sol|
           next if sol[:some_type] && @klass.type_uri(@collection) != sol[:some_type]
@@ -74,8 +74,8 @@ module Goo
           add_object_to_model(id, objects, object, predicate)
         end
       
-
-        @lang_filter.enrich_models(@models_by_id)
+        # for this moment we are not going to enrich models , maybe we will use it if the results are empty  
+        # @lang_filter.enrich_models(@models_by_id)
 
         init_unloaded_attributes(found, list_attributes)
 

--- a/lib/goo/sparql/solutions_mapper.rb
+++ b/lib/goo/sparql/solutions_mapper.rb
@@ -75,7 +75,7 @@ module Goo
         end
       
         # for this moment we are not going to enrich models , maybe we will use it if the results are empty  
-        # @lang_filter.enrich_models(@models_by_id)
+        @lang_filter.enrich_models(@models_by_id)
 
         init_unloaded_attributes(found, list_attributes)
 

--- a/lib/goo/sparql/solutions_mapper.rb
+++ b/lib/goo/sparql/solutions_mapper.rb
@@ -4,7 +4,7 @@ module Goo
       BNODES_TUPLES = Struct.new(:id, :attribute)
 
       def initialize(aggregate_projections, bnode_extraction, embed_struct,
-                     incl_embed, klass_struct, models_by_id,
+                      incl_embed, klass_struct, models_by_id,
                      properties_to_include, unmapped, variables, ids, options)
 
         @aggregate_projections = aggregate_projections
@@ -22,7 +22,7 @@ module Goo
         @incl = options[:include]
         @count = options[:count]
         @collection = options[:collection]
-        @requested_lang =  options[:requested_lang] || :ALL
+        @requested_lang =  get_language(options[:requested_lang].to_s) 
       end
       
       def map_each_solutions(select)
@@ -101,6 +101,13 @@ module Goo
       end
 
       private
+
+      def get_language(languages)
+        languages = 'ALL' if languages.nil? || languages.empty? 
+        lang = languages.split(',').map {|l| l.upcase.to_sym}
+        return lang.length == 1 ? lang.first : lang
+      end
+
 
       def init_unloaded_attributes(found, list_attributes)
         return if @incl.nil?


### PR DESCRIPTION
## Description

This pull request adds a new branch called language_return_all that returns all existing result when the requested language value is set to "all". This feature was implemented based on the request described in issue https://github.com/agroportal/project-management/issues/307

## Changes Made / Todos

- [x] Added new branch called language_return_all .

- [x] Implemented logic to return all existing result when the requested language value is set to "all".
- [x] Set @language to the requested language [ ontoportal-lirmm/ontologies_linked_data/pull/80 ]
- [x] Support select multilanguages 688ec5e8bdcba6b1f3bfaca7e4c2fd15f299d924
- [x] Show the values in all languages with their corresponding language. [ agroportal/project-management/issues/307 ]
- [x] In @language return the available languages for the result not the requested languages https://github.com/ontoportal-lirmm/ontologies_linked_data/pull/80/commits/fad47b4efc051afb46fc0c942fe837c140da2353
- [x] Make it works for all attribues not only `synonyms` and `prefLabel`
- [x] Fix tests


## Screenshots

use case :  [localhost:9393/ontologies/INRAETHES/classes](http://localhost:9393/ontologies/INRAETHES/classes/http%3A%2F%2Fopendata.inrae.fr%2FthesaurusINRAE%2Fc_22817?display=synonym)

1. `requested_lang = all` 
![image](https://user-images.githubusercontent.com/35062242/234591592-e0367f20-f719-4927-ad32-912eda8bc504.png)
2.  `requested_lang = fr` 
![image](https://user-images.githubusercontent.com/35062242/234591437-fb60397f-28ef-4fed-a992-c4617981d021.png)
3.  `requested_lang = en` 
![image](https://user-images.githubusercontent.com/35062242/234591237-4d41033c-5be2-4fe4-b157-99fd12c8b3f3.png)
4.  `requested_lang = fr,en` 
![image](https://user-images.githubusercontent.com/35062242/234591027-f15fcb04-084d-4c2d-b01d-0865217faeb1.png)

## Resources & Informations

For the `requested_lang = all`, we need to show the values in all languages but also their corresponding language, like this 
![image](https://user-images.githubusercontent.com/29259906/233851768-5c835f6e-4667-4b74-b267-5115ceeb1c91.png)

For the case none languages :

![image](https://user-images.githubusercontent.com/29259906/234820497-79b561fe-9047-4cad-8327-a975955325b4.png)

So for your use case of synonyms, it needs to be like this: 

```json
# if attribute of type list
"synonym": {
"en": ["syn_en_1", "syn_en_2"],
"fr": ["syn_fr_1"]
}
# if attribute of type no-list
"prefLabel": {
"en": "label_en_1",
"fr": "label_fr_1"
}

```

The global  issue that describes this is here: https://github.com/agroportal/project-management/issues/307



## Reviewers
@syphax-bouazzouni 


