### PR TITLE
Feature: Make  the regex filter no-case sensitive

### DIFF
--- a/lib/goo/sparql/query_builder.rb
+++ b/lib/goo/sparql/query_builder.rb
@@ -321,7 +321,7 @@ module Goo
               return :optional
             when :regex
               if  filter_operation.value.is_a?(String)
-                filter_operations << "REGEX(STR(?#{filter_var.to_s}) , \"#{filter_operation.value.to_s}\")"
+                filter_operations << "REGEX(STR(?#{filter_var.to_s}) , \"#{filter_operation.value.to_s}\", \"i\")"
               end
 
             else


### PR DESCRIPTION
### Changes

Make the REGEX filter not sensitive by adding the "i" flag, so that for example it will match the terms "test", "Test", "TEST",... for a given attribute.


#### Before
```
REGEX(pattern , value) # case sensitive 
```
#### After 
```
REGEX(pattern , value, 'i') # no-case sensitive 
```
