### PR TITLE
group unmapped properties by lang

### DIFF
--- a/lib/goo/base/resource.rb
+++ b/lib/goo/base/resource.rb
@@ -15,7 +15,7 @@ module Goo
       attr_reader :modified_attributes
       attr_reader :errors
       attr_reader :aggregates
-      attr_reader :unmapped
+      attr_accessor :unmapped
 
       attr_reader :id
 
@@ -129,6 +129,7 @@ module Goo
 
       def unmmaped_to_array
         cpy = {}
+        
         @unmapped.each do |attr,v|
           cpy[attr] = v.to_a
         end

--- a/lib/goo/sparql/mixins/solution_lang_filter.rb
+++ b/lib/goo/sparql/mixins/solution_lang_filter.rb
@@ -51,8 +51,23 @@ module Goo
           store_objects_by_lang(model.id, predicate, value, language)
         end
 
+        def model_group_by_lang(model, requested_lang)
+          unmapped = model.unmapped 
+          cpy = {}
+  
+          unmapped.each do |attr, v|          
+             cpy[attr] = is_a_uri?(v.first) ? v.to_a : v.group_by { |x| x.language.to_s }
+          end
+  
+          model.unmapped = cpy
+        end
+
 
         private
+
+        def is_a_uri?(value)
+          value.is_a?(RDF::URI) && value.valid?
+        end
 
         def object_language(new_value)
           new_value.language || :no_lang if new_value.is_a?(RDF::Literal)

--- a/lib/goo/sparql/solutions_mapper.rb
+++ b/lib/goo/sparql/solutions_mapper.rb
@@ -35,6 +35,7 @@ module Goo
            list_attributes: list_attributes)
         
         select.each_solution do |sol|
+          
           next if sol[:some_type] && @klass.type_uri(@collection) != sol[:some_type]
           return sol[:count_var].object if @count
 
@@ -96,7 +97,8 @@ module Goo
         include_bnodes(blank_nodes, @models_by_id) unless blank_nodes.empty?
 
         models_unmapped_to_array(@models_by_id) if @unmapped
-
+        
+        
         @models_by_id
       end
 
@@ -269,8 +271,18 @@ module Goo
 
       def models_unmapped_to_array(models_by_id)
         models_by_id.each do |_idm, m|
-          m.unmmaped_to_array
+          if is_multiple_langs?
+            @lang_filter.model_group_by_lang(m, @requested_lang)
+          else
+            m.unmmaped_to_array
+          end
         end
+      end
+
+
+      def is_multiple_langs?
+        return true if @requested_lang.is_a?(Array) || @requested_lang.eql?(:ALL)
+        false
       end
 
       def include_bnodes(bnodes, models_by_id)


### PR DESCRIPTION

## Description

**Previously**, when we requested all languages, the unmapped properties were not grouped by language in the result.
**Currcently**, the unmapped properties are grouped by language.

Follow up : #239 

## Screenshots

![image](https://github.com/ontoportal/goo/assets/35062242/77e20cf0-5896-4fe6-af82-d827a603b9be)


## Changes made : 

- Add a new method called `model_group_by_lang `to the `language_filter` class.
- Modify the existing `models_unmapped_to_array `method to check if the request_language is multiple. in this case we call the `model_group_by_lang `method instead.

## Reviewers
@syphax-bouazzouni 

