### PR TITLE
Feature: Refactor and fix the Language filter method 

### DIFF
--- a/lib/goo/base/resource.rb
+++ b/lib/goo/base/resource.rb
@@ -15,7 +15,7 @@ module Goo
       attr_reader :modified_attributes
       attr_reader :errors
       attr_reader :aggregates
-      attr_accessor :unmapped
+      attr_writer :unmapped
 
       attr_reader :id
 
@@ -134,6 +134,12 @@ module Goo
           cpy[attr] = v.to_a
         end
         @unmapped = cpy
+      end
+
+      def unmapped(*args)
+        @unmapped.transform_values do  |language_values|
+          self.class.not_show_all_languages?(language_values, args) ?  language_values.values.flatten: language_values
+        end
       end
 
       def delete(*args)

--- a/lib/goo/base/settings/settings.rb
+++ b/lib/goo/base/settings/settings.rb
@@ -275,7 +275,12 @@ module Goo
           end
           define_method("#{attr}") do |*args|
             attr_value = self.instance_variable_get("@#{attr}")
-            attr_value = attr_value.values.first if  attr_value.is_a?(Hash) && !args.include?(:show_with_language)
+
+            if self.class.not_show_all_languages?(attr_value, args)
+              is_array = attr_value.values.first.is_a?(Array)
+              attr_value = attr_value.values.flatten
+              attr_value = attr_value.first unless is_array
+            end
 
 
             if self.class.handler?(attr)
@@ -393,6 +398,14 @@ module Goo
           instance.klass = self
           attributes.each {|k,v| instance[k] = v}
           instance
+        end
+
+        def show_all_languages?(args)
+          args.include?(:show_with_language)
+        end
+
+        def not_show_all_languages?(values, args)
+          values.is_a?(Hash) && !show_all_languages?(args)
         end
 
         private

--- a/lib/goo/base/settings/settings.rb
+++ b/lib/goo/base/settings/settings.rb
@@ -401,7 +401,7 @@ module Goo
         end
 
         def show_all_languages?(args)
-          args.include?(:show_with_language)
+          args.first.is_a?(Hash) && args.first.keys.include?(:show_languages) && args.first[:show_languages]
         end
 
         def not_show_all_languages?(values, args)

--- a/lib/goo/sparql/mixins/solution_lang_filter.rb
+++ b/lib/goo/sparql/mixins/solution_lang_filter.rb
@@ -5,12 +5,12 @@ module Goo
         
         attr_reader :requested_lang, :unmapped, :objects_by_lang
 
-        def initialize(requested_lang: nil, unmapped: false, list_attributes: [])
+        def initialize(requested_lang: RequestStore.store[:requested_lang], unmapped: false, list_attributes: [])
           @attributes_to_translate = [:synonym, :prefLabel, :definition, :label]
           @list_attributes = list_attributes
           @objects_by_lang = {}
           @unmapped = unmapped
-          @requested_lang = requested_lang
+          @requested_lang = get_language(requested_lang)
         end
 
         def enrich_models(models_by_id)

--- a/lib/goo/sparql/mixins/solution_lang_filter.rb
+++ b/lib/goo/sparql/mixins/solution_lang_filter.rb
@@ -63,6 +63,13 @@ module Goo
           model.unmapped = cpy
         end
 
+        def models_unmapped_to_array(m)
+          if show_all_languages?
+            model_group_by_lang(m)
+          else
+            m.unmmaped_to_array
+          end
+        end
 
         private
 
@@ -155,8 +162,18 @@ module Goo
         end
 
 
-        def literal?(object)
-          return object_language(object).nil? ? false : true
+        def show_all_languages?
+          @requested_lang.is_a?(Array) || @requested_lang.eql?(:ALL)
+        end
+
+        def get_language(languages)
+          languages = portal_language if languages.nil? || languages.empty?
+          lang = languages.to_s.split(',').map { |l| l.upcase.to_sym }
+          lang.length == 1 ? lang.first : lang
+        end
+
+        def portal_language
+          Goo.main_languages.first
         end
 
       end

--- a/lib/goo/sparql/mixins/solution_lang_filter.rb
+++ b/lib/goo/sparql/mixins/solution_lang_filter.rb
@@ -120,15 +120,6 @@ module Goo
         end
 
 
-        def get_model_attribute_value(model, predicate)
-          if unmapped
-            unmapped_get(model, predicate)
-          else
-            model.instance_variable_get("@#{predicate}")
-          end
-        end
-
-
         def add_unmapped_to_model(model, predicate, value)
           
           if model.respond_to? :klass # struct

--- a/lib/goo/sparql/mixins/solution_lang_filter.rb
+++ b/lib/goo/sparql/mixins/solution_lang_filter.rb
@@ -145,7 +145,11 @@ module Goo
             add_unmapped_to_model(model, predicate, values) 
 
           else 
-            values = values.map { |k, v| [k, v.first] }.to_h unless list_attributes?(predicate)
+            values = values.map do  |language, values_literals|
+              values_string = values_literals.map{|x| x.object}
+              values_string = values_string.first unless list_attributes?(predicate)
+              [language, values_string]
+            end.to_h
 
             model.send("#{predicate}=", values, on_load: true)
           end

--- a/lib/goo/sparql/mixins/solution_lang_filter.rb
+++ b/lib/goo/sparql/mixins/solution_lang_filter.rb
@@ -6,7 +6,6 @@ module Goo
         attr_reader :requested_lang, :unmapped, :objects_by_lang
 
         def initialize(requested_lang: RequestStore.store[:requested_lang], unmapped: false, list_attributes: [])
-          @attributes_to_translate = [:synonym, :prefLabel, :definition, :label]
           @list_attributes = list_attributes
           @objects_by_lang = {}
           @unmapped = unmapped

--- a/lib/goo/sparql/mixins/solution_lang_filter.rb
+++ b/lib/goo/sparql/mixins/solution_lang_filter.rb
@@ -2,7 +2,7 @@ module Goo
   module SPARQL
     module Solution
       class  LanguageFilter
-        
+
         attr_reader :requested_lang, :unmapped, :objects_by_lang
 
         def initialize(requested_lang: RequestStore.store[:requested_lang], unmapped: false, list_attributes: [])
@@ -12,54 +12,29 @@ module Goo
           @requested_lang = get_language(requested_lang)
         end
 
-        def enrich_models(models_by_id)
-          
+        def fill_models_with_all_languages(models_by_id)
           objects_by_lang.each do |id, predicates|
             model = models_by_id[id]
-            predicates.each do |predicate, values|   
-            
+            predicates.each do |predicate, values|
+
               if values.values.all? { |v| v.all? { |x| literal?(x) && x.plain?} }
-                save_model_values(model, values, predicate, unmapped)
-                
-              end 
+                pull_stored_values(model, values, predicate, @unmapped)
+              end
             end
-          end  
-        end
-        
-
-        def set_model_value(model, predicate, objects, object)
-                    
-          language = object_language(object)
-
-          if requested_lang.eql?(:ALL) || !literal?(object) || language_match?(language)
-            model.send("#{predicate}=", objects, on_load: true)
-          end 
-
-          if requested_lang.eql?(:ALL) || requested_lang.is_a?(Array)
-            language = "@none" if language.nil? || language.eql?(:no_lang)
-            store_objects_by_lang(model.id, predicate, object, language)
           end
-
         end
 
-        def model_set_unmapped(model, predicate, value)
-          language = object_language(value)
-          if requested_lang.eql?(:ALL) || language.nil? || language_match?(language)
+
+        def set_model_value(model, predicate, values, value)
+          set_value(model, predicate, value) do
+            model.send("#{predicate}=", values, on_load: true)
+          end
+        end
+
+        def set_unmapped_value(model, predicate, value)
+          set_value(model, predicate, value) do
             return add_unmapped_to_model(model, predicate, value)
           end
-          
-          store_objects_by_lang(model.id, predicate, value, language)
-        end
-
-        def model_group_by_lang(model, requested_lang)
-          unmapped = model.unmapped 
-          cpy = {}
-  
-          unmapped.each do |attr, v|          
-            cpy[attr] = group_by_lang(v)
-          end
-  
-          model.unmapped = cpy
         end
 
         def models_unmapped_to_array(m)
@@ -72,16 +47,41 @@ module Goo
 
         private
 
+
+        def set_value(model, predicate, value, &block)
+          language = object_language(value)
+
+          if requested_lang.eql?(:ALL) || !literal?(value) || language_match?(language)
+            block.call
+          end
+
+          if requested_lang.eql?(:ALL) || requested_lang.is_a?(Array)
+            language = "@none" if language.nil? || language.eql?(:no_lang)
+            store_objects_by_lang(model.id, predicate, value, language)
+          end
+        end
+        
+        def model_group_by_lang(model)
+          unmapped = model.unmapped
+          cpy = {}
+
+          unmapped.each do |attr, v|
+            cpy[attr] = group_by_lang(v)
+          end
+
+          model.unmapped = cpy
+        end
+
         def group_by_lang(values)
-          
+
           return values.to_a if is_a_uri?(values.first)
-          
+
           values = values.group_by { |x| x.language ? x.language.to_s.downcase : :none }
-                              
+
           no_lang = values[:none] || []
           return no_lang if !no_lang.empty? && no_lang.all? { |x| !x.plain? }
 
-          values 
+          values
         end
 
         def is_a_uri?(value)
@@ -94,24 +94,23 @@ module Goo
 
         def language_match?(language)
           # no_lang means that the object is not a literal
-          if language.eql?(:no_lang)
-            return true 
-          end
+          return true if language.eql?(:no_lang)
 
-          if requested_lang.is_a?(Array)
-            return requested_lang.include?(language)
-          end
+          return requested_lang.include?(language)  if requested_lang.is_a?(Array)
 
-          return language.eql?(requested_lang)
+          language.eql?(requested_lang)
+        end
 
+        def literal?(object)
+          !object_language(object).nil?
         end
 
         def store_objects_by_lang(id, predicate, object, language)
           # store objects in this format: [id][predicate][language] = [objects]
           return if requested_lang.is_a?(Array) && !requested_lang.include?(language)
 
-          language_key = language.downcase  
-            
+          language_key = language.downcase
+
           objects_by_lang[id] ||= {}
           objects_by_lang[id][predicate] ||= {}
           objects_by_lang[id][predicate][language_key] ||= []
@@ -121,7 +120,7 @@ module Goo
 
 
         def add_unmapped_to_model(model, predicate, value)
-          
+
           if model.respond_to? :klass # struct
             model[:unmapped] ||= {}
             model[:unmapped][predicate] ||= []
@@ -131,11 +130,10 @@ module Goo
           end
         end
 
-        def save_model_values(model, values, predicate, unmapped)
+        def pull_stored_values(model, values, predicate, unmapped)
           if unmapped
-            add_unmapped_to_model(model, predicate, values) 
-
-          else 
+            add_unmapped_to_model(model, predicate, values)
+          else
             values = values.map do  |language, values_literals|
               values_string = values_literals.map{|x| x.object}
               values_string = values_string.first unless list_attributes?(predicate)

--- a/lib/goo/sparql/solutions_mapper.rb
+++ b/lib/goo/sparql/solutions_mapper.rb
@@ -76,7 +76,7 @@ module Goo
         end
       
         # for this moment we are not going to enrich models , maybe we will use it if the results are empty  
-        @lang_filter.enrich_models(@models_by_id)
+        @lang_filter.fill_models_with_all_languages(@models_by_id)
 
         init_unloaded_attributes(found, list_attributes)
 
@@ -419,7 +419,7 @@ module Goo
         id = sol[:id]
         value = sol[:attributeObject]
 
-        @lang_filter.model_set_unmapped(@models_by_id[id], @properties_to_include[predicate][:uri], value)
+        @lang_filter.set_unmapped_value(@models_by_id[id], @properties_to_include[predicate][:uri], value)
       end
 
       def add_aggregations_to_model(sol)

--- a/lib/goo/sparql/solutions_mapper.rb
+++ b/lib/goo/sparql/solutions_mapper.rb
@@ -104,16 +104,6 @@ module Goo
 
       private
 
-      def get_language(languages)
-        languages = portal_language if languages.nil? || languages.empty?
-        lang = languages.split(',').map {|l| l.upcase.to_sym}
-        lang.length == 1 ? lang.first : lang
-      end
-
-      def portal_language
-        Goo.main_languages.first
-      end
-
       def init_unloaded_attributes(found, list_attributes)
         return if @incl.nil?
 
@@ -271,11 +261,7 @@ module Goo
 
       def models_unmapped_to_array(models_by_id)
         models_by_id.each do |_idm, m|
-          if is_multiple_langs?
-            @lang_filter.model_group_by_lang(m, @requested_lang)
-          else
-            m.unmmaped_to_array
-          end
+          @lang_filter.models_unmapped_to_array(m)
         end
       end
 

--- a/lib/goo/sparql/solutions_mapper.rb
+++ b/lib/goo/sparql/solutions_mapper.rb
@@ -22,7 +22,7 @@ module Goo
         @incl = options[:include]
         @count = options[:count]
         @collection = options[:collection]
-        @requested_lang =  get_language(options[:requested_lang].to_s) 
+        @options = options
       end
       
       def map_each_solutions(select)
@@ -31,7 +31,7 @@ module Goo
         list_attributes = Set.new(@klass.attributes(:list))
         all_attributes = Set.new(@klass.attributes(:all))
 
-        @lang_filter = Goo::SPARQL::Solution::LanguageFilter.new(requested_lang: @requested_lang, unmapped: @unmapped,
+        @lang_filter = Goo::SPARQL::Solution::LanguageFilter.new(requested_lang: @options[:requested_lang].to_s, unmapped: @unmapped,
            list_attributes: list_attributes)
         
         select.each_solution do |sol|


### PR DESCRIPTION
### Context 
This PR does a global rewrite and refactor of all the work done in the Multilingual topic with the PRs listed bellow
- https://github.com/ontoportal-lirmm/goo/pull/40 
- https://github.com/ontoportal-lirmm/goo/pull/39 
- https://github.com/ontoportal-lirmm/goo/pull/38 
- https://github.com/ontoportal-lirmm/goo/pull/37 
- https://github.com/ontoportal-lirmm/goo/pull/32
- https://github.com/ontoportal-lirmm/goo/pull/24

### Changes

- Give better names to the methods 
- Remove unused methods and variables 
- Limit the coupling between the two modules of SolutionMapper and LangFilter;
- Replace the getters argument to show languages from `:show_all_languages` to `show_languages: true` (https://github.com/ontoportal-lirmm/goo/pull/41/commits/e26009af8a11ffbc6a7ab016c41645b76bcac936)
- Fix save_model_values method to not save `RDF:Literal` object but a string (https://github.com/ontoportal-lirmm/goo/pull/41/commits/a990260bdea958ce293c1de75234ee0c25fb9213)
- Fix getters for list attributes to not take only the first value (https://github.com/ontoportal-lirmm/goo/pull/41/commits/94959cd3c34c2d7d6fa27b9220aa908d67114cd3)
