### PR TITLE
Feature: Make map_attribute support showing all languages - Support multi language search

### DIFF
--- a/lib/goo/base/resource.rb
+++ b/lib/goo/base/resource.rb
@@ -361,13 +361,13 @@ module Goo
 
 
 
-      def self.map_attributes(inst,equivalent_predicates=nil)
+      def self.map_attributes(inst,equivalent_predicates=nil, include_languages: false)
         if (inst.kind_of?(Goo::Base::Resource) && inst.unmapped.nil?) ||
           (!inst.respond_to?(:unmapped) && inst[:unmapped].nil?)
           raise ArgumentError, "Resource.map_attributes only works for :unmapped instances"
         end
         klass = inst.respond_to?(:klass) ? inst[:klass] : inst.class
-        unmapped = inst.respond_to?(:klass) ? inst[:unmapped] : inst.unmapped
+        unmapped = inst.respond_to?(:klass) ? inst[:unmapped] : inst.unmapped(include_languages: include_languages)
         list_attrs = klass.attributes(:list)
         unmapped_string_keys = Hash.new
         unmapped.each do |k,v|
@@ -398,13 +398,18 @@ module Goo
               object = unmapped_string_keys[attr_uri]
             end
 
-            object = object.map {|o| o.is_a?(RDF::URI) ? o : o.object}
+            if object.is_a?(Hash)
+              object = object.transform_values{|values| Array(values).map{|o|o.is_a?(RDF::URI) ? o : o.object}}
+            else
+              object = object.map {|o| o.is_a?(RDF::URI) ? o : o.object}
+            end
 
             if klass.range(attr)
               object = object.map { |o|
                 o.is_a?(RDF::URI) ? klass.range_object(attr,o) : o }
             end
-            object = object.first unless list_attrs.include?(attr)
+
+            object = object.first unless list_attrs.include?(attr) || include_languages
             if inst.respond_to?(:klass)
               inst[attr] = object
             else

--- a/lib/goo/base/settings/settings.rb
+++ b/lib/goo/base/settings/settings.rb
@@ -401,7 +401,7 @@ module Goo
         end
 
         def show_all_languages?(args)
-          args.first.is_a?(Hash) && args.first.keys.include?(:show_languages) && args.first[:show_languages]
+          args.first.is_a?(Hash) && args.first.keys.include?(:include_languages) && args.first[:include_languages]
         end
 
         def not_show_all_languages?(values, args)


### PR DESCRIPTION
### Context

Follow up of https://github.com/ontoportal-lirmm/goo/pull/41

This PR makes 'map_attributes` method handle the option showing all the languages; this method is used to map the unmapped values to the mapped ones (e.g skos:prefLabel to the model attribute prefLabel) and is used in the indexation process.

So making the method multilingual is mandatory and the first step to make the search/index multilingual.

### Changes 

- Change the getters show_all_languages argument from to include_languages (https://github.com/ontoportal-lirmm/goo/commit/5952f8708f64f0a28dcf2ae44c4d8e4610682448)
- Make the `map_attributes` method  handle the option showing all the languages (https://github.com/ontoportal-lirmm/goo/commit/a81f12ca1d5d6cf7c4b7c30718ff6bd8e4a56aff)