### PR TITLE
Fix: pagination with order_by & filter that returns empty pages for 4store

### DIFF
--- a/lib/goo/sparql/query_builder.rb
+++ b/lib/goo/sparql/query_builder.rb
@@ -33,7 +33,8 @@ module Goo
 
         @order_by, variables, optional_patterns = init_order_by(@count, @klass, @order_by, optional_patterns, variables,patterns, query_options, graphs)
 
-
+        query_filter_str, patterns, optional_patterns, filter_variables =
+          filter_query_strings(@collection, graphs, internal_variables, @klass, optional_patterns, patterns, @query_filters)
         variables = [] if @count
         variables.delete :some_type
 

--- a/test/test_where.rb
+++ b/test/test_where.rb
@@ -262,6 +262,17 @@ class TestWhere < MiniTest::Unit::TestCase
     end
   end
 
+  def test_paging_with_filter_order
+    total_count = Student.where.count
+    page_1 = Student.where.page(1, total_count - 1).order_by(name: :asc).to_a
+    refute_empty page_1
+    assert page_1.next?
+    page_2 = Student.where.page(page_1.next_page, total_count - 1).order_by(name: :asc).to_a
+
+
+    refute_empty page_2
+    assert_equal total_count, page_1.size + page_2.size
+  end
 
   def test_unique_object_references
 


### PR DESCRIPTION
fix for https://github.com/ontoportal-lirmm/ontologies_api/issues/25