### PR TITLE
Fix: enforce to use str() when doing a filter with a string value 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ PATH
   remote: .
   specs:
     goo (0.0.2)
+      addressable (~> 2.8)
       pry
       rdf (= 3.2.11)
       rdf-raptor
@@ -32,6 +33,8 @@ GEM
       multi_json (~> 1.3)
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
     base64 (0.2.0)
     builder (3.2.4)
     coderay (1.1.3)
@@ -71,7 +74,8 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    rack (2.2.8)
+    public_suffix (5.0.4)
+    rack (2.2.8.1)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-post-body-to-params (0.1.8)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       retries: 5
 
   agraph-ut:
-    image: franzinc/agraph:v8.0.0.rc1
+    image: franzinc/agraph:v8.1.0
     platform: linux/amd64
     environment:
       - AGRAPH_SUPER_USER=test

--- a/goo.gemspec
+++ b/goo.gemspec
@@ -6,6 +6,7 @@ Gem::Specification.new do |s|
   s.email = "manuelso@stanford.edu"
   s.files = Dir["lib/**/*.rb"]
   s.homepage = "http://github.com/ncbo/goo"
+  s.add_dependency("addressable", "~> 2.8")
   s.add_dependency("pry")
   s.add_dependency("rdf", "3.2.11") #unpin when we support only Ruby >= 3.0
   s.add_dependency("rdf-vocab")

--- a/lib/goo/sparql/query_builder.rb
+++ b/lib/goo/sparql/query_builder.rb
@@ -383,9 +383,12 @@ module Goo
               value = RDF::Literal.new(filter_operation.value)
               if filter_operation.value.is_a? String
                 value = RDF::Literal.new(filter_operation.value)
+                filter_var = "str(?#{filter_var})"
+              else
+                filter_var = "?#{filter_var}"
               end
               filter_operations << (
-                "?#{filter_var.to_s} #{sparql_op_string(filter_operation.operator)} " +
+                "#{filter_var.to_s} #{sparql_op_string(filter_operation.operator)} " +
                   " #{value.to_ntriples}")
             end
 


### PR DESCRIPTION
### Issue 
Saving the value of a triple as T021"^^xsd:string is not the same as "T021" (in 4store at least), the first one get be get using  this query 
```
  ?id <http://www.w3.org/2004/02/skos/core#notation> ?v .
  FILTER(?v = "T021")
```

and the latter 

```
  ?id <http://www.w3.org/2004/02/skos/core#notation> ?v .
  FILTER(?v = "T021"^^xsd:string)
```


### Solution 
To handle both cases this PR enforce the usage of `str()` in SPARQL filters, 
```
  ?id <http://www.w3.org/2004/02/skos/core#notation> ?v .
  FILTER(str(?v) = "T021")
```

 