### PR TITLE
Fix: Invalidating cache after insertion of a new  element

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,5 +22,5 @@ group :profiling do
   gem "thin"
 end
 
-gem 'sparql-client', github: 'ontoportal-lirmm/sparql-client', branch: 'feature/reset-to-upstream'
+gem 'sparql-client', github: 'ontoportal-lirmm/sparql-client', branch: 'development'
 gem 'faraday', '2.7.11' #unpin if we no more support ruby 2.7

--- a/Gemfile
+++ b/Gemfile
@@ -22,5 +22,5 @@ group :profiling do
   gem "thin"
 end
 
-gem 'sparql-client', github: 'ontoportal-lirmm/sparql-client', branch: 'master'
+gem 'sparql-client', github: 'ontoportal-lirmm/sparql-client', branch: 'feature/reset-to-upstream'
 gem 'faraday', '2.7.11' #unpin if we no more support ruby 2.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,11 @@
 GIT
   remote: https://github.com/ontoportal-lirmm/sparql-client.git
-  revision: 180c818f7715baac64b2699bb452ef5c756f62c5
-  branch: master
+  revision: 04e904dbef4037e08e748574ab0f56d4f560a512
+  branch: feature/reset-to-upstream
   specs:
-    sparql-client (1.0.1)
-      json_pure (>= 1.4)
-      net-http-persistent (= 2.9.4)
-      rdf (>= 1.0)
+    sparql-client (3.2.2)
+      net-http-persistent (~> 4.0, >= 4.0.2)
+      rdf (~> 3.2, >= 3.2.11)
 
 PATH
   remote: .
@@ -57,25 +56,25 @@ GEM
       domain_name (~> 0.5)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    json_pure (2.7.1)
     link_header (0.0.8)
     macaddr (1.7.2)
       systemu (~> 2.6.5)
-    method_source (1.0.0)
+    method_source (1.1.0)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.0206)
+    mime-types-data (3.2024.0305)
     minitest (4.7.5)
     multi_json (1.15.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
-    net-http-persistent (2.9.4)
+    net-http-persistent (4.0.2)
+      connection_pool (~> 2.2)
     netrc (0.11.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    public_suffix (5.0.4)
-    rack (2.2.8.1)
+    public_suffix (5.0.5)
+    rack (2.2.9)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-post-body-to-params (0.1.8)
@@ -83,7 +82,7 @@ GEM
     rack-protection (3.2.0)
       base64 (>= 0.1.0)
       rack (~> 2.2, >= 2.2.4)
-    rake (13.1.0)
+    rake (13.2.1)
     rdf (3.2.11)
       link_header (~> 0.0, >= 0.0.8)
     rdf-raptor (3.2.0)
@@ -99,9 +98,9 @@ GEM
     rdf-xsd (3.2.1)
       rdf (~> 3.2)
       rexml (~> 3.2)
-    redis (5.1.0)
-      redis-client (>= 0.17.0)
-    redis-client (0.20.0)
+    redis (5.2.0)
+      redis-client (>= 0.22.0)
+    redis-client (0.22.1)
       connection_pool
     request_store (1.6.0)
       rack (>= 1.4)
@@ -111,7 +110,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rexml (3.2.6)
-    rsolr (2.5.0)
+    rsolr (2.6.0)
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
     ruby2_keywords (0.0.5)
@@ -163,4 +162,4 @@ DEPENDENCIES
   uuid
 
 BUNDLED WITH
-   2.2.33
+   2.4.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/ontoportal-lirmm/sparql-client.git
   revision: c96da3ad479724a31ccd6217ab9939dddfaca40e
-  branch: feature/reset-to-upstream
+  branch: development
   specs:
     sparql-client (3.2.2)
       net-http-persistent (~> 4.0, >= 4.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ontoportal-lirmm/sparql-client.git
-  revision: 04e904dbef4037e08e748574ab0f56d4f560a512
+  revision: c96da3ad479724a31ccd6217ab9939dddfaca40e
   branch: feature/reset-to-upstream
   specs:
     sparql-client (3.2.2)

--- a/lib/goo.rb
+++ b/lib/goo.rb
@@ -117,24 +117,26 @@ module Goo
     opts = opts[0]
     @@sparql_backends = @@sparql_backends.dup
     @@sparql_backends[name] = opts
-    @@sparql_backends[name][:query]=Goo::SPARQL::Client.new(opts[:query],
-                 {protocol: "1.1", "Content-Type" => "application/x-www-form-urlencoded",
-                   read_timeout: 10000,
-                   validate: false,
-                   redis_cache: @@redis_client,
-                   cube_options: @@cube_options})
-    @@sparql_backends[name][:update]=Goo::SPARQL::Client.new(opts[:update],
-                 {protocol: "1.1", "Content-Type" => "application/x-www-form-urlencoded",
-                   read_timeout: 10000,
-                   validate: false,
-                   redis_cache: @@redis_client,
-                   cube_options: @@cube_options})
-    @@sparql_backends[name][:data]=Goo::SPARQL::Client.new(opts[:data],
-                 {protocol: "1.1", "Content-Type" => "application/x-www-form-urlencoded",
-                   read_timeout: 10000,
-                   validate: false,
-                   redis_cache: @@redis_client,
-                   cube_options: @@cube_options})
+    @@sparql_backends[name][:query] = Goo::SPARQL::Client.new(opts[:query],
+                                                              protocol: "1.1",
+                                                              headers: { "Content-Type" => "application/x-www-form-urlencoded", "Accept" => "application/sparql-results+json"},
+                                                              read_timeout: 10000,
+                                                              validate: false,
+                                                              redis_cache: @@redis_client)
+    @@sparql_backends[name][:update] = Goo::SPARQL::Client.new(opts[:update],
+                                                               protocol: "1.1",
+                                                               headers: { "Content-Type" => "application/x-www-form-urlencoded", "Accept" => "application/sparql-results+json"},
+                                                               read_timeout: 10000,
+                                                               validate: false,
+                                                               redis_cache: @@redis_client,
+                                                               cube_options: @@cube_options)
+    @@sparql_backends[name][:data] = Goo::SPARQL::Client.new(opts[:data],
+                                                             protocol: "1.1",
+                                                             headers: { "Content-Type" => "application/x-www-form-urlencoded", "Accept" => "application/sparql-results+json"},
+                                                             read_timeout: 10000,
+                                                             validate: false,
+                                                             redis_cache: @@redis_client,
+                                                             cube_options: @@cube_options)
     @@sparql_backends[name][:backend_name] = opts[:backend_name]
     @@sparql_backends.freeze
   end
@@ -255,7 +257,7 @@ module Goo
     yield self
     configure_sanity_check
 
-      init_search_connections
+    init_search_connections
 
     @@namespaces.freeze
     @@sparql_backends.freeze

--- a/lib/goo/base/resource.rb
+++ b/lib/goo/base/resource.rb
@@ -293,8 +293,7 @@ module Goo
               batch_file.write(lines.join(""))
               batch_file.flush()
             else
-              data = graph_insert.to_a.reduce("") { |acc, x| acc << x.to_s + " " }
-              Goo.sparql_data_client.execute_append_request(graph, data, "application/x-turtle")
+              Goo.sparql_update_client.insert_data(graph_insert, graph: graph)
             end
           rescue Exception => e
             raise e

--- a/lib/goo/base/resource.rb
+++ b/lib/goo/base/resource.rb
@@ -293,7 +293,7 @@ module Goo
               batch_file.write(lines.join(""))
               batch_file.flush()
             else
-              Goo.sparql_update_client.insert_data(graph_insert, graph: graph)
+              Goo.sparql_update_client.insert_data(graph_insert, graph: graph, use_insert_data: !Goo.backend_vo?)
             end
           rescue Exception => e
             raise e

--- a/lib/goo/config/config.rb
+++ b/lib/goo/config/config.rb
@@ -68,11 +68,13 @@ module Goo
     if @@sparql_backends[:main][:query].url.to_s["localhost"].nil?
       raise Exception, "only for testing"
     end
-    @@sparql_backends[:main][:query] = Goo::SPARQL::Client.new("http://#{@settings.goo_host}:#{@settings.goo_port}#{@settings.goo_path_query}",
-                                                             {protocol: "1.1", "Content-Type" => "application/x-www-form-urlencoded",
-                                                              read_timeout: 300,
-                                                              redis_cache: @@redis_client })
+    @@sparql_backends = {}
+    Goo.add_sparql_backend(:main,
+                            backend_name: @settings.goo_backend_name,
+                            query: "http://#{@settings.goo_host}:#{@settings.goo_port}#{@settings.goo_path_query}",
+                            data: "http://#{@settings.goo_host}:#{@settings.goo_port}#{@settings.goo_path_data}",
+                            update: "http://#{@settings.goo_host}:#{@settings.goo_port}#{@settings.goo_path_update}",
+                            options: { rules: :NONE })
   end
-
 
 end

--- a/lib/goo/sparql/query_builder.rb
+++ b/lib/goo/sparql/query_builder.rb
@@ -51,7 +51,9 @@ module Goo
           @query.filter(filter)
         end
 
-        @query.union(*@unions) unless @unions.empty?
+        Array(@unions).each do |union|
+          @query.union(*union)
+        end
 
         ids_filter(ids) if ids
 

--- a/test/test_cache.rb
+++ b/test/test_cache.rb
@@ -26,6 +26,19 @@ class TestCache < MiniTest::Unit::TestCase
     GooTestData.delete_test_case_data
   end
 
+  def test_cache_invalidate
+    address = Address.all.first
+    Goo.use_cache = true
+    puts "save 1"
+    University.new(name: 'test', address: [address]).save
+    u2 = University.new(name: 'test', address: [address])
+    puts "request 1"
+    refute u2.valid?
+    expected_error = { :name => { :duplicate => "There is already a persistent resource with id `http://goo.org/default/university/test`" } }
+    assert_equal expected_error, u2.errors
+    Goo.use_cache = false
+  end
+
   def test_cache_models
     redis = Goo.redis_client
     redis.flushdb
@@ -49,7 +62,7 @@ class TestCache < MiniTest::Unit::TestCase
     assert !key.nil?
     assert redis.exists(key)
 
-    
+
     prg = programs.first
     prg.bring_remaining
     prg.credits = 999


### PR DESCRIPTION
### Require 
* https://github.com/ontoportal-lirmm/sparql-client/pull/1
### Context
after #48, we used `Goo.sparql_data_client.execute_append_request(graph,data, "application/x-turtle")` to insert data into a graph, the issue is that this function don't invalidate the cache.

Before that we used  `Goo.sparql_update_client.insert_data(graph_insert, graph: graph)` which invalidate the cache but did not work for Virtuoso.

So this PR reverted back to use `Goo.sparql_update_client.insert_data` but in the same time make it work for Virtuoso.

### Changes
* Create a test to reproduce the cache invalidate on insert bug (https://github.com/ontoportal-lirmm/goo/commit/10cd78188d1d169ee5ad06ed7c7a581a7a3f630d)
* Use again insert_data instead of execute_append_request because the first invalidate the cache (https://github.com/ontoportal-lirmm/goo/commit/4d40f15386eaae3498c2ec00e5b6011ec69a61a6) 
* Update sparql client to version 3.2.0 (https://github.com/ontoportal-lirmm/goo/commit/3838ce9358011732c2e1d139f5e42d17dcc675a9)