### PR TITLE
Fix: show multiple languages tags

### DIFF
--- a/lib/goo/sparql/solutions_mapper.rb
+++ b/lib/goo/sparql/solutions_mapper.rb
@@ -28,8 +28,17 @@ module Goo
         objects_new = {}
         list_attributes = Set.new(@klass.attributes(:list))
 
-        @lang_filter = Goo::SPARQL::Solution::LanguageFilter.new(requested_lang: @options[:requested_lang].to_s, unmapped: @unmapped,
-                                                                 list_attributes: list_attributes)
+        @lang_filter = Goo::SPARQL::Solution::LanguageFilter.new(requested_lang: @options[:requested_lang], unmapped: @unmapped,
+           list_attributes: list_attributes)
+        
+        if @options[:page]
+          # for using prefixes before queries
+          # mdorf, 7/27/2023, AllegroGraph supplied a patch (rfe17161-7.3.1.fasl.patch)
+          # that enables implicit internal ordering. The patch requires the prefix below
+          select.prefix('franzOption_imposeImplicitBasicOrdering: <franz:yes>')
+          # mdorf, 1/24/2024, AllegroGraph 8 introduced a new feature that allows caching OFFSET/LIMIT queries
+          select.prefix('franzOption_allowCachingResults: <franz:yes>')
+        end
 
         select.each_solution do |sol|
 

--- a/test/data/languages.nt
+++ b/test/data/languages.nt
@@ -1,0 +1,9 @@
+<http://data.bioontology.org/resource1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://data.bioontology.org/Person> .
+<http://data.bioontology.org/resource1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#label> "John Doe"@en .
+<http://data.bioontology.org/resource1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#label> "Jean Dupont"@fr .
+<http://data.bioontology.org/resource1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#label> "Juan Pérez" .
+<http://data.bioontology.org/resource2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://data.bioontology.org/Place> .
+<http://data.bioontology.org/resource2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#label> "Paris"@en .
+<http://data.bioontology.org/resource2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#label> "Paris"@fr .
+<http://data.bioontology.org/resource2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#label> "París"@es .
+<http://data.bioontology.org/resource2> <http://www.w3.org/1999/02/22-rdf-syntax-ns#label> "Berlin" .

--- a/test/test_languages_filters.rb
+++ b/test/test_languages_filters.rb
@@ -1,0 +1,90 @@
+require_relative "test_case"
+require_relative './app/models'
+
+
+
+class ExamplePerson < Goo::Base::Resource
+  model :person, namespace: :bioportal, name_with: lambda { |k| k.id },
+        collection: :db
+  attribute :db, enforce: [ :database ]
+  attribute :label, namespace: :rdf, enforce: [ :list ]
+end
+
+class ExamplePlace < Goo::Base::Resource
+  model :place, namespace: :bioportal, name_with: lambda { |k| k.id },
+        collection: :db
+  attribute :db, enforce: [ :database ]
+  attribute :label, namespace: :rdf, enforce: [ :list ]
+end
+
+class TestLanguageFilter < MiniTest::Unit::TestCase
+  def self.before_suite
+    RequestStore.store[:requested_lang] = Goo.main_languages.first
+    graph = RDF::URI.new(Test::Models::DATA_ID)
+
+    database = Test::Models::Database.new
+    database.id = graph
+    database.name = "Census tiger 2002"
+    database.save
+
+    @@db = Test::Models::Database.find(RDF::URI.new(Test::Models::DATA_ID)).first
+    @@person_id = RDF::URI.new "http://data.bioontology.org/resource1"
+
+
+    ntriples_file_path = "./test/data/languages.nt"
+
+    Goo.sparql_data_client.put_triples(
+      graph,
+      ntriples_file_path,
+      mime_type = "application/x-turtle")
+  end
+
+  def self.after_suite
+    graph = RDF::URI.new(Test::Models::DATA_ID)
+    Goo.sparql_data_client.delete_graph(graph)
+    database = Test::Models::Database.find(RDF::URI.new(Test::Models::DATA_ID)).first
+    database.delete if database
+    RequestStore.store[:requested_lang] = Goo.main_languages.first
+  end
+
+  def setup
+    RequestStore.store[:requested_lang] = Goo.main_languages.first
+  end
+
+  def test_one_language
+    # by default english and not tagged values
+    person = ExamplePerson.find(@@person_id).in(@@db).include(:label).first
+    assert_equal ["John Doe", "Juan Pérez"].sort, person.label.sort
+
+
+    # select french, return french values and not tagged values
+    RequestStore.store[:requested_lang] = :fr
+    person = ExamplePerson.find(@@person_id).in(@@db).include(:label).first
+    assert_equal ["Jean Dupont", "Juan Pérez"].sort, person.label.sort
+
+  end
+
+  def test_multiple_languages
+    # select all languages
+    RequestStore.store[:requested_lang] = :all
+    expected_result = {:en=>["John Doe"], :fr=>["Jean Dupont"], "@none"=>["Juan Pérez"]}
+    person = ExamplePerson.find(@@person_id).in(@@db).include(:label).first
+    assert_equal expected_result.values.flatten.sort, person.label.sort
+
+    # using include_languages on any attribute returns an hash of {language: values} instead of the array of values
+    assert_equal expected_result, person.label(include_languages: true)
+
+    # filter only french, english and not tagged values
+    RequestStore.store[:requested_lang] = [:fr, :en]
+    person = ExamplePerson.find(@@person_id).in(@@db).include(:label).first
+    assert_equal expected_result.values.flatten.sort.sort, person.label.sort
+  end
+
+
+  def test_language_not_found
+    RequestStore.store[:requested_lang] = :ar
+    person = ExamplePerson.find(@@person_id).in(@@db).include(:label).first
+    # will return only not tagged values if existent
+    assert_equal ["Juan Pérez"], person.label
+  end
+end

--- a/test/test_languages_filters.rb
+++ b/test/test_languages_filters.rb
@@ -78,6 +78,7 @@ class TestLanguageFilter < MiniTest::Unit::TestCase
     RequestStore.store[:requested_lang] = [:fr, :en]
     person = ExamplePerson.find(@@person_id).in(@@db).include(:label).first
     assert_equal expected_result.values.flatten.sort.sort, person.label.sort
+    assert_equal expected_result, person.label(include_languages: true)
   end
 
 


### PR DESCRIPTION
fix https://github.com/ontoportal/ontoportal-project/issues/57

### Changes
* Add multilingual support tests (https://github.com/ontoportal-lirmm/goo/commit/7e58da39a6af682226e109b7bbb38a7b8475a288)
* Update the lang filter module to include language tags values if multiple languages selected (https://github.com/ontoportal-lirmm/goo/commit/4954e565ff6cb593c867bd5a53b21eb53df12bca) 
