### PR TITLE
Fix: parsing ontologies issue, when concept label is url

### DIFF
--- a/lib/goo/sparql/mixins/solution_lang_filter.rb
+++ b/lib/goo/sparql/mixins/solution_lang_filter.rb
@@ -14,10 +14,10 @@ module Goo
 
         def fill_models_with_all_languages(models_by_id)
           objects_by_lang.each do |id, predicates|
+
             model = models_by_id[id]
             predicates.each do |predicate, values|
-
-              if values.values.all? { |v| v.all? { |x| literal?(x) && x.plain?} }
+              if values.values.any? { |v| v.all? { |x| literal?(x) && x.plain?} }
                 pull_stored_values(model, values, predicate, @unmapped)
               end
             end
@@ -142,10 +142,10 @@ module Goo
             add_unmapped_to_model(model, predicate, values)
           else
             values = values.map do  |language, values_literals|
-              values_string = values_literals.map{|x| x.object}
+              values_string = values_literals.select{|x| literal?(x) && x.plain?}.map{|x| x.object}
               values_string = values_string.first unless list_attributes?(predicate)
               [language, values_string]
-            end.to_h
+            end.to_h.reject { |_key, value| value.empty? }
 
             model.send("#{predicate}=", values, on_load: true)
           end


### PR DESCRIPTION
### Issue description
When a class contains labels of type IRI (e.g., the one shown below):
![image](https://github.com/user-attachments/assets/f4a8a117-ef0d-4a3f-82a0-943eb345a39d)

It causes the language tags in the code to break, leading to an interruption in the ontology processing.

### Affected Ontologies
The following ontologies fail to parse due to this issue:
https://agroportal.lirmm.fr/ontologies/CDNO
https://agroportal.lirmm.fr/ontologies/FOODON
https://agroportal.lirmm.fr/ontologies/PCSM
https://agroportal.lirmm.fr/ontologies/APTO


### Changes
This pull request addresses the issue by ensuring that only labels of type literal are tagged with language tags.



### Testing
This code has been tested in the following pull request: 
