### PR TITLE
Fix: suite PR#66 (parsing ontologies issue, when concept label is a typed literal)

### DIFF
--- a/lib/goo/sparql/mixins/solution_lang_filter.rb
+++ b/lib/goo/sparql/mixins/solution_lang_filter.rb
@@ -17,7 +17,9 @@ module Goo
 
             model = models_by_id[id]
             predicates.each do |predicate, values|
-              if values.values.any? { |v| v.all? { |x| literal?(x) && x.plain?} }
+
+              if values.values.any? { |v| v.any? { |x| literal?(x) && x.plain?} }
+
                 pull_stored_values(model, values, predicate, @unmapped)
               end
             end


### PR DESCRIPTION
### Context
When multiple labels within the same concept lack language tags, and some of these labels are not plain literals, the remaining plain literal labels still need to be tagged with appropriate language tags.

### Changes
This PR completes the fix introduced in [PR #66](https://github.com/ontoportal-lirmm/goo/pull/66). The updated logic ensures that any label that is a plain literal will be tagged, regardless of whether all labels in the concept are plain literals (as previously required).

