### PR TITLE
Fix: bring attributes that has the handler

### DIFF
--- a/lib/goo/base/resource.rb
+++ b/lib/goo/base/resource.rb
@@ -179,13 +179,13 @@ module Goo
       def bring(*opts)
         opts.each do |k|
           if k.kind_of?(Hash)
-            k.each do |k2,v|
-              raise ArgumentError, "Unable to bring a method based attr #{k2}" if self.class.handler?(k2)
-              self.instance_variable_set("@#{k2}",nil)
+            k.each do |k2,_|
+              instance_variable_set("@#{k2}", nil)
+              send(k2) if self.class.handler?(k2)
             end
           else
-            raise ArgumentError, "Unable to bring a method based attr #{k}" if self.class.handler?(k)
-            self.instance_variable_set("@#{k}",nil)
+            instance_variable_set("@#{k}", nil)
+            send(k) if self.class.handler?(k)
           end
         end
         query = self.class.where.models([self]).include(*opts)

--- a/lib/goo/base/where.rb
+++ b/lib/goo/base/where.rb
@@ -260,13 +260,13 @@ module Goo
         options.each do |opt|
           if opt.instance_of?(Symbol)
             if @klass.handler?(opt)
-              raise ArgumentError, "Method based attribute cannot be included"
+              next
             end
           end
           if opt.instance_of?(Hash)
             opt.each do |k,v|
               if @klass.handler?(k)
-                raise ArgumentError, "Method based attribute cannot be included"
+                next
               end
             end
           end

--- a/test/test_model_complex.rb
+++ b/test/test_model_complex.rb
@@ -98,19 +98,26 @@ class TestModelComplex < MiniTest::Unit::TestCase
     x.id = RDF::URI.new "http://someiri.org/term/x"
     x.prefLabel = "x"
     x.save
-    assert_raises ArgumentError do
-      y = Term.find(x.id).in(sub).include(:methodBased).first
-    end
+    # Chech the methodBased is not included
+    y = Term.find(x.id).in(sub).include(:methodBased).first
+    assert_kind_of TestComplex::Term, y
+    refute y.loaded_attributes.include?(:methodBased)
+    
     assert_raises ArgumentError do
       y = Term.find(x.id).in(sub).include(methodBased: [:prefLabel]).first
     end
-    assert_raises ArgumentError do
-      y = Term.where.in(sub).include(:methodBased).all
-    end
+  
+    # Chech there is result and the methodBased is not included
+    y = Term.where.in(sub).include(:methodBased).all
+    assert_kind_of Array, y
+    refute_empty y
+    assert_kind_of TestComplex::Term, y.first
+    refute y.first.loaded_attributes.include?(:methodBased)
+    
+    # Chech the methodBased is brought by the bring
     y = Term.find(x.id).in(sub).first
-    assert_raises ArgumentError do
-      y.bring(:methodBased)
-    end
+    y.bring(:methodBased)
+    assert_includes y.loaded_attributes.to_a, :methodBased
     y.delete
     sub.delete
   end


### PR DESCRIPTION
- Fix for: https://github.com/ontoportal-lirmm/goo/issues/72

### Solution
The error was caused because by default the attributes that has handler will not be brought by the bring method, so the solution was to send them and not raise an error.

In the where.rb file these attributes will not be included so that they will not be in the sparql query because they are not saved in the triple store 