### PR TITLE
Feature: Migrate to ruby 3.2

### DIFF
--- a/.github/workflows/ruby-unit-test.yml
+++ b/.github/workflows/ruby-unit-test.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         goo-slice: [ '100']
-        ruby-version: [ '2.7', '3.2.0' ]
+        ruby-version: [ '3.2.0' ]
         triplestore: [ 'fs', 'ag', 'vo', 'gb' ]
 
     steps:

--- a/.github/workflows/ruby-unit-test.yml
+++ b/.github/workflows/ruby-unit-test.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goo-slice: [ '20', '100', '500' ]
-        ruby-version: [ '2.7', '3.0' ]
+        goo-slice: [ '100']
+        ruby-version: [ '2.7', '3.2.0' ]
         triplestore: [ 'fs', 'ag', 'vo', 'gb' ]
 
     steps:
@@ -34,4 +34,3 @@ jobs:
       run: GOO_SLICES=${{ matrix.goo-slice }} bundle exec rake test:docker:${{ matrix.triplestore }} TESTOPTS="-v"
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
-

--- a/Gemfile
+++ b/Gemfile
@@ -23,5 +23,9 @@ group :profiling do
 end
 
 gem 'sparql-client', github: 'ontoportal-lirmm/sparql-client', branch: 'development'
-gem 'faraday', '2.7.11' #unpin if we no more support ruby 2.7
 gem "rdf-raptor", github: "ruby-rdf/rdf-raptor", ref: "6392ceabf71c3233b0f7f0172f662bd4a22cd534" # use version 3.3.0 when available
+
+# to remove if no more supporting ruby 2.7
+gem 'faraday', '2.7.11' #unpin if we no more support ruby 2.7
+gem 'net-ftp'
+gem 'public_suffix', '~> 5.1.1'

--- a/Gemfile
+++ b/Gemfile
@@ -24,3 +24,4 @@ end
 
 gem 'sparql-client', github: 'ontoportal-lirmm/sparql-client', branch: 'development'
 gem 'faraday', '2.7.11' #unpin if we no more support ruby 2.7
+gem "rdf-raptor", github: "ruby-rdf/rdf-raptor", ref: "6392ceabf71c3233b0f7f0172f662bd4a22cd534" # use version 3.3.0 when available

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 gem "activesupport"
-gem "cube-ruby", require: "cube"
 gem "rake"
 gem "uuid"
 gem "request_store"
@@ -24,8 +23,8 @@ end
 
 gem 'sparql-client', github: 'ontoportal-lirmm/sparql-client', branch: 'development'
 gem "rdf-raptor", github: "ruby-rdf/rdf-raptor", ref: "6392ceabf71c3233b0f7f0172f662bd4a22cd534" # use version 3.3.0 when available
-
-# to remove if no more supporting ruby 2.7
-gem 'faraday', '2.7.11' #unpin if we no more support ruby 2.7
 gem 'net-ftp'
-gem 'public_suffix', '~> 5.1.1'
+
+# # to remove if no more supporting ruby 2.7
+# gem 'faraday', '2.7.11' #unpin if we no more support ruby 2.7
+# gem 'public_suffix', '~> 5.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,20 @@
 GIT
   remote: https://github.com/ontoportal-lirmm/sparql-client.git
-  revision: d4737ff08f33517cf93b4d82c78a471017991d97
+  revision: 736b7650e28db3ce5e3e49511ac30f958a29e8f1
   branch: development
   specs:
     sparql-client (3.2.2)
       net-http-persistent (~> 4.0, >= 4.0.2)
       rdf (~> 3.2, >= 3.2.11)
+
+GIT
+  remote: https://github.com/ruby-rdf/rdf-raptor.git
+  revision: 6392ceabf71c3233b0f7f0172f662bd4a22cd534
+  ref: 6392ceabf71c3233b0f7f0172f662bd4a22cd534
+  specs:
+    rdf-raptor (3.3.0)
+      ffi (~> 1.15)
+      rdf (~> 3.3)
 
 PATH
   remote: .
@@ -13,7 +22,7 @@ PATH
     goo (0.0.2)
       addressable (~> 2.8)
       pry
-      rdf (= 3.2.11)
+      rdf
       rdf-raptor
       rdf-rdfxml
       rdf-vocab
@@ -35,6 +44,8 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     base64 (0.2.0)
+    bcp47_spec (0.2.1)
+    bigdecimal (3.1.9)
     builder (3.3.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
@@ -64,7 +75,7 @@ GEM
     mime-types (3.6.0)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2025.0107)
+    mime-types-data (3.2025.0204)
     minitest (4.7.5)
     multi_json (1.15.0)
     mustermann (3.0.3)
@@ -75,7 +86,7 @@ GEM
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    public_suffix (5.1.1)
+    public_suffix (6.0.1)
     rack (2.2.10)
     rack-accept (0.4.5)
       rack (>= 0.4)
@@ -85,20 +96,19 @@ GEM
       base64 (>= 0.1.0)
       rack (~> 2.2, >= 2.2.4)
     rake (13.2.1)
-    rdf (3.2.11)
+    rdf (3.3.2)
+      bcp47_spec (~> 0.2)
+      bigdecimal (~> 3.1, >= 3.1.5)
       link_header (~> 0.0, >= 0.0.8)
-    rdf-raptor (3.2.0)
-      ffi (~> 1.15)
-      rdf (~> 3.2)
-    rdf-rdfxml (3.2.2)
-      builder (~> 3.2)
+    rdf-rdfxml (3.3.0)
+      builder (~> 3.2, >= 3.2.4)
       htmlentities (~> 4.3)
-      rdf (~> 3.2)
-      rdf-xsd (~> 3.2)
-    rdf-vocab (3.2.7)
-      rdf (~> 3.2, >= 3.2.4)
-    rdf-xsd (3.2.1)
-      rdf (~> 3.2)
+      rdf (~> 3.3)
+      rdf-xsd (~> 3.3)
+    rdf-vocab (3.3.2)
+      rdf (~> 3.3)
+    rdf-xsd (3.3.0)
+      rdf (~> 3.3)
       rexml (~> 3.2)
     redis (5.3.0)
       redis-client (>= 0.22.0)
@@ -142,6 +152,7 @@ GEM
       macaddr (~> 1.0)
 
 PLATFORMS
+  arm64-darwin-24
   x86_64-darwin-23
   x86_64-linux
 
@@ -155,6 +166,7 @@ DEPENDENCIES
   rack-accept
   rack-post-body-to-params
   rake
+  rdf-raptor!
   request_store
   simplecov
   simplecov-cobertura

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,24 +50,26 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
-    cube-ruby (0.0.3)
     daemons (1.4.1)
     date (3.4.1)
     docile (1.4.1)
     domain_name (0.6.20240107)
     eventmachine (1.2.7)
-    faraday (2.7.11)
-      base64
-      faraday-net_http (>= 2.0, < 3.1)
-      ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.2)
-    ffi (1.17.1)
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
+    ffi (1.17.1-arm64-darwin)
+    ffi (1.17.1-x86_64-linux-gnu)
     htmlentities (4.3.4)
     http-accept (1.7.0)
     http-cookie (1.0.8)
       domain_name (~> 0.5)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    json (2.9.1)
     link_header (0.0.8)
     logger (1.6.5)
     macaddr (1.7.2)
@@ -84,6 +86,8 @@ GEM
     net-ftp (0.3.8)
       net-protocol
       time
+    net-http (0.6.0)
+      uri
     net-http-persistent (4.0.5)
       connection_pool (~> 2.2)
     net-protocol (0.2.2)
@@ -92,7 +96,7 @@ GEM
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    public_suffix (5.1.1)
+    public_suffix (6.0.1)
     rack (2.2.10)
     rack-accept (0.4.5)
       rack (>= 0.4)
@@ -157,23 +161,20 @@ GEM
       date
     timeout (0.4.3)
     tzinfo (0.3.62)
+    uri (1.0.2)
     uuid (2.3.9)
       macaddr (~> 1.0)
 
 PLATFORMS
   arm64-darwin-24
-  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
   activesupport
-  cube-ruby
-  faraday (= 2.7.11)
   goo!
   minitest (< 5.0)
   net-ftp
   pry
-  public_suffix (~> 5.1.1)
   rack-accept
   rack-post-body-to-params
   rake
@@ -187,4 +188,4 @@ DEPENDENCIES
   uuid
 
 BUNDLED WITH
-   2.4.22
+   2.6.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
     connection_pool (2.5.0)
     cube-ruby (0.0.3)
     daemons (1.4.1)
+    date (3.4.1)
     docile (1.4.1)
     domain_name (0.6.20240107)
     eventmachine (1.2.7)
@@ -80,13 +81,18 @@ GEM
     multi_json (1.15.0)
     mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
+    net-ftp (0.3.8)
+      net-protocol
+      time
     net-http-persistent (4.0.5)
       connection_pool (~> 2.2)
+    net-protocol (0.2.2)
+      timeout
     netrc (0.11.0)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    public_suffix (6.0.1)
+    public_suffix (5.1.1)
     rack (2.2.10)
     rack-accept (0.4.5)
       rack (>= 0.4)
@@ -147,6 +153,9 @@ GEM
       rack (>= 1, < 3)
     thread_safe (0.3.6)
     tilt (2.6.0)
+    time (0.4.1)
+      date
+    timeout (0.4.3)
     tzinfo (0.3.62)
     uuid (2.3.9)
       macaddr (~> 1.0)
@@ -162,7 +171,9 @@ DEPENDENCIES
   faraday (= 2.7.11)
   goo!
   minitest (< 5.0)
+  net-ftp
   pry
+  public_suffix (~> 5.1.1)
   rack-accept
   rack-post-body-to-params
   rake

--- a/config/config.rb.sample
+++ b/config/config.rb.sample
@@ -15,7 +15,7 @@ Goo.config do |config|
   # config.goo_path_data     = "/repositories/ontoportal/statements/"
   # config.goo_path_update   = "/repositories/ontoportal/statements/"
 
-  config.search_server_url   = 'http://localhost:8983/solr/term_search_core1'
+  config.search_server_url   = 'http://localhost:8983/solr/'
   config.redis_host          = 'localhost'
   config.redis_port          = 6379
   config.bioportal_namespace = 'http://data.bioontology.org/'

--- a/goo.gemspec
+++ b/goo.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/ncbo/goo"
   s.add_dependency("addressable", "~> 2.8")
   s.add_dependency("pry")
-  s.add_dependency("rdf")#unpin when we support only Ruby >= 3.0
+  s.add_dependency("rdf")
   s.add_dependency("rdf-vocab")
   s.add_dependency("rdf-rdfxml")
   s.add_dependency("rdf-raptor")

--- a/goo.gemspec
+++ b/goo.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/ncbo/goo"
   s.add_dependency("addressable", "~> 2.8")
   s.add_dependency("pry")
-  s.add_dependency("rdf", "3.2.11") #unpin when we support only Ruby >= 3.0
+  s.add_dependency("rdf")#unpin when we support only Ruby >= 3.0
   s.add_dependency("rdf-vocab")
   s.add_dependency("rdf-rdfxml")
   s.add_dependency("rdf-raptor")

--- a/lib/goo.rb
+++ b/lib/goo.rb
@@ -12,7 +12,6 @@ require 'rsolr'
 require 'rest_client'
 require 'redis'
 require 'uuid'
-require "cube"
 
 require_relative "goo/config/config"
 require_relative "goo/sparql/sparql"
@@ -46,7 +45,6 @@ module Goo
   @@default_namespace = nil
   @@id_prefix = nil
   @@redis_client = nil
-  @@cube_options = nil
   @@namespaces = {}
   @@pluralize_models = false
   @@uuid = UUID.new
@@ -130,15 +128,13 @@ module Goo
                                                                headers: { "Content-Type" => "application/x-www-form-urlencoded", "Accept" => "application/sparql-results+json"},
                                                                read_timeout: 10000,
                                                                validate: false,
-                                                               redis_cache: @@redis_client,
-                                                               cube_options: @@cube_options)
+                                                               redis_cache: @@redis_client)
     @@sparql_backends[name][:data] = Goo::SPARQL::Client.new(opts[:data],
                                                              protocol: "1.1",
                                                              headers: { "Content-Type" => "application/x-www-form-urlencoded", "Accept" => "application/sparql-results+json"},
                                                              read_timeout: 10000,
                                                              validate: false,
-                                                             redis_cache: @@redis_client,
-                                                             cube_options: @@cube_options)
+                                                             redis_cache: @@redis_client)
     @@sparql_backends[name][:backend_name] = opts[:backend_name]
     @@sparql_backends.freeze
   end

--- a/lib/goo/config/config.rb
+++ b/lib/goo/config/config.rb
@@ -24,10 +24,10 @@ module Goo
     @settings.redis_host          ||= ENV['REDIS_HOST'] || 'localhost'
     @settings.redis_port          ||= ENV['REDIS_PORT'] || 6379
     @settings.bioportal_namespace ||= ENV['BIOPORTAL_NAMESPACE'] || 'http://data.bioontology.org/'
-    @settings.query_logging     ||= ENV['QUERIES_LOGGING'] || false
-    @settings.query_logging_file||= ENV['QUERIES_LOGGING_FILE'] || './sparql.log'
+    @settings.query_logging       ||= ENV['QUERIES_LOGGING'] || false
+    @settings.query_logging_file  ||= ENV['QUERIES_LOGGING_FILE'] || './sparql.log'
     @settings.queries_debug       ||= ENV['QUERIES_DEBUG'] || false
-    @settings.slice_loading_size  ||= ENV['GOO_SLICES'] || 500
+    @settings.slice_loading_size  ||= ENV['GOO_SLICES']&.to_i || 500
     puts "(GOO) >> Using RDF store (#{@settings.goo_backend_name}) #{@settings.goo_host}:#{@settings.goo_port}#{@settings.goo_path_query}"
     puts "(GOO) >> Using term search server at #{@settings.search_server_url}"
     puts "(GOO) >> Using Redis instance at #{@settings.redis_host}:#{@settings.redis_port}"
@@ -62,6 +62,7 @@ module Goo
         conf.add_namespace(:nemo, RDF::Vocabulary.new("http://purl.bioontology.org/NEMO/ontology/NEMO_annotation_properties.owl#"))
         conf.add_namespace(:bioportal, RDF::Vocabulary.new(@settings.bioportal_namespace))
         conf.use_cache = false
+        conf.slice_loading_size = @settings.slice_loading_size
       end
     rescue StandardError => e
       abort("EXITING: Goo cannot connect to triplestore and/or search server:\n  #{e}\n#{e.backtrace.join("\n")}")

--- a/test/test_logging.rb
+++ b/test/test_logging.rb
@@ -26,7 +26,7 @@ class TestLogging < MiniTest::Unit::TestCase
     Goo.logger.info("Test logging")
     University.all
     recent_logs = Goo.logger.get_logs
-    assert_equal 3, recent_logs.length
+    assert_equal 2, recent_logs.length
     assert recent_logs.any? { |x| x['query'].include?("Test logging") }
     assert File.read("test.log").include?("Test logging")
   end
@@ -35,7 +35,7 @@ class TestLogging < MiniTest::Unit::TestCase
     Goo.logger.info("Test logging 2")
     University.all
     recent_logs = Goo.logger.queries_last_n_seconds(1)
-    assert_equal 3, recent_logs.length
+    assert_equal 2, recent_logs.length
     assert recent_logs.any? { |x| x['query'].include?("Test logging 2") }
     assert File.read("test.log").include?("Test logging 2")
     sleep 1


### PR DESCRIPTION
> Warning starting from this release, we no more support ruby 2.

## Changes
* Unpin RDF version and use latest `rdf-raptor` version (https://github.com/ontoportal-lirmm/goo/pull/74/commits/15f1223c27f5991ac166ffc782ddcb3cc517f245)
* Pin gem public_suffix for ruby 2.7 (https://github.com/ontoportal-lirmm/goo/pull/74/commits/bc30defd609b4656ea2918c7fb4e971ab2791d6d)
* Remove cube and ruby 2 pinned gems (https://github.com/ontoportal-lirmm/goo/pull/74/commits/c49b6185e15d7e16e3e4c06470fb10a078495900)
* Remove ruby 2 CI tests (https://github.com/ontoportal-lirmm/goo/pull/74/commits/dd3ea6c0f583c2044622a9f872a0bd18e898bb79)